### PR TITLE
Fix pline intersect function to use pos_equal_eps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to the cavalier_contours crate will be documented in this fi
 
 - Added `#[inline]` attribute to all of the small Vector2 and base math functions.
 
+### Fixed 🐛
+
+- Fixed polyline find_intersects to use pos_equal_eps passed in options for querying bounding boxes
+  ([#22](https://github.com/jbuckmccready/cavalier_contours/pull/22)).
+
 ## 0.2.0
 
 ### Added ⭐

--- a/cavalier_contours/src/polyline/internal/pline_intersects.rs
+++ b/cavalier_contours/src/polyline/internal/pline_intersects.rs
@@ -137,7 +137,6 @@ where
 
     let mut visited_pairs = HashSet::with_capacity(vc);
     let mut query_stack = Vec::with_capacity(8);
-    let fuzz = T::fuzzy_epsilon();
 
     // iterate all segment bounding boxes in the spatial index querying itself to test for self
     // intersects
@@ -215,10 +214,10 @@ where
         };
 
         aabb_index.visit_query_with_stack(
-            aabb.min_x - fuzz,
-            aabb.min_y - fuzz,
-            aabb.max_x + fuzz,
-            aabb.max_y + fuzz,
+            aabb.min_x - pos_equal_eps,
+            aabb.min_y - pos_equal_eps,
+            aabb.max_x + pos_equal_eps,
+            aabb.max_y + pos_equal_eps,
             &mut query_visitor,
             &mut query_stack,
         );
@@ -395,14 +394,13 @@ where
         };
 
         let bb = seg_fast_approx_bounding_box(p2v1, p2v2);
-        let fuzz = T::fuzzy_epsilon();
 
         let mut query_stack = Vec::with_capacity(8);
         pline1_aabb_index.visit_query_with_stack(
-            bb.min_x - fuzz,
-            bb.min_y - fuzz,
-            bb.max_x + fuzz,
-            bb.max_y + fuzz,
+            bb.min_x - pos_equal_eps,
+            bb.min_y - pos_equal_eps,
+            bb.max_x + pos_equal_eps,
+            bb.max_y + pos_equal_eps,
             &mut query_visitor,
             &mut query_stack,
         );

--- a/cavalier_contours/src/polyline/internal/pline_intersects.rs
+++ b/cavalier_contours/src/polyline/internal/pline_intersects.rs
@@ -1139,6 +1139,30 @@ mod find_intersects_tests {
         assert_fuzzy_eq!(intr2.point1, pline2[1].pos());
         assert_fuzzy_eq!(intr2.point2, pline2[0].pos());
     }
+
+    #[test]
+    fn uses_pos_equal_eps() {
+        // test that pos_equal_eps passed in options is used
+        let eps = 1e-5;
+        let mut pline1 = Polyline::new();
+        pline1.add(0.5, 0.0, 0.0);
+        pline1.add(0.5, 1.0 - 0.99 * eps, 0.0);
+
+        let mut pline2 = Polyline::new();
+        pline2.add(0.0, 1.0, 0.0);
+        pline2.add(1.0, 1.0, 0.0);
+
+        let opts = FindIntersectsOptions {
+            pos_equal_eps: eps,
+            ..Default::default()
+        };
+
+        let intrs = find_intersects(&pline1, &pline2, &opts);
+        assert_eq!(intrs.basic_intersects.len(), 1);
+        assert!(intrs.overlapping_intersects.is_empty());
+        let intr = intrs.basic_intersects[0];
+        assert_fuzzy_eq!(intr.point, Vector2::new(0.5, 1.0));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In case of segments not intersecting but close enough (in pos_equal_eps box) there will be incorrect behavior. If bound boxes isn't overlap but segments intrsects.
For examle: 2 perpendicular segments
    *
    |
    |
    *
*-------*
with distance between less than pos_equal_eps but greter than T::epsilon()
In that case should be intersection but it won't