### PR TITLE
fix: remove_redundant panics on polyline with equal points

### DIFF
--- a/cavalier_contours/src/polyline/traits.rs
+++ b/cavalier_contours/src/polyline/traits.rs
@@ -550,7 +550,10 @@ pub trait PlineSource {
         let mut i = 2;
         while v1.pos().fuzzy_eq_eps(v2.pos(), pos_equal_eps) {
             v1.bulge = v2.bulge;
-            if i >= vc { break; } //check for reaching the end of polyline
+            // check for reaching the end of polyline
+            if i >= vc {
+                break;
+            }
             v2 = self.at(i);
             i += 1;
         }
@@ -563,7 +566,9 @@ pub trait PlineSource {
             Some(pl)
         };
         // if end is reached return polyline with the only vertex
-        if i >= vc { return result; }
+        if i >= vc {
+            return result;
+        }
 
         let mut v1_v2_arc: Option<(Self::Num, Vector2<Self::Num>)> = None;
         let mut v1_bulge_is_zero = v1.bulge_is_zero();

--- a/cavalier_contours/src/polyline/traits.rs
+++ b/cavalier_contours/src/polyline/traits.rs
@@ -514,13 +514,11 @@ pub trait PlineSource {
         }
 
         if vc == 2 {
-            if self
-                .at(0)
-                .pos()
-                .fuzzy_eq_eps(self.at(1).pos(), pos_equal_eps)
-            {
+            let v1 = self.at(0);
+            let v2 = self.at(1);
+            if v1.pos().fuzzy_eq_eps(v2.pos(), pos_equal_eps) {
                 let mut result = Self::OutputPolyline::with_capacity(1, self.is_closed());
-                result.add_vertex(self.at(0));
+                result.add_vertex(v2); // take bulge from last vertex
                 return Some(result);
             }
             return None;
@@ -552,7 +550,7 @@ pub trait PlineSource {
         let mut i = 2;
         while v1.pos().fuzzy_eq_eps(v2.pos(), pos_equal_eps) {
             v1.bulge = v2.bulge;
-            if i >= vc { break; }
+            if i >= vc { break; } //check for reaching the end of polyline
             v2 = self.at(i);
             i += 1;
         }
@@ -564,6 +562,7 @@ pub trait PlineSource {
             pl.add_vertex(v1);
             Some(pl)
         };
+        // if end is reached return polyline with the only vertex
         if i >= vc { return result; }
 
         let mut v1_v2_arc: Option<(Self::Num, Vector2<Self::Num>)> = None;

--- a/cavalier_contours/src/polyline/traits.rs
+++ b/cavalier_contours/src/polyline/traits.rs
@@ -552,6 +552,7 @@ pub trait PlineSource {
         let mut i = 2;
         while v1.pos().fuzzy_eq_eps(v2.pos(), pos_equal_eps) {
             v1.bulge = v2.bulge;
+            if i >= vc { break; }
             v2 = self.at(i);
             i += 1;
         }
@@ -563,6 +564,7 @@ pub trait PlineSource {
             pl.add_vertex(v1);
             Some(pl)
         };
+        if i >= vc { return result; }
 
         let mut v1_v2_arc: Option<(Self::Num, Vector2<Self::Num>)> = None;
         let mut v1_bulge_is_zero = v1.bulge_is_zero();

--- a/cavalier_contours/tests/test_pline_basics.rs
+++ b/cavalier_contours/tests/test_pline_basics.rs
@@ -878,13 +878,19 @@ fn remove_redundant() {
         polyline2.add(1.0, 1.0, 0.0);
         polyline2.add(1.0, 1.0, 0.0);
         polyline2.add(1.0, 1.0, 1.0);
+        let mut polyline3 = Polyline::with_capacity(2, false);
+        polyline3.add(2.0, 2.0, 0.0);
+        polyline3.add(2.0, 2.0, 1.0);
 
         let r1 = polyline1.remove_redundant(1e-5).unwrap();
         let r2 = polyline2.remove_redundant(1e-5).unwrap();
+        let r3 = polyline3.remove_redundant(1e-5).unwrap();
         assert_eq!(r1.vertex_count(), 1);
         assert_eq!(r2.vertex_count(), 1);
+        assert_eq!(r3.vertex_count(), 1);
         assert_fuzzy_eq!(r1[0], PlineVertex::new(0.0, 0.0, 0.0));
         assert_fuzzy_eq!(r2[0], PlineVertex::new(1.0, 1.0, 1.0));
+        assert_fuzzy_eq!(r3[0], PlineVertex::new(2.0, 2.0, 1.0));
     }
 }
 

--- a/cavalier_contours/tests/test_pline_basics.rs
+++ b/cavalier_contours/tests/test_pline_basics.rs
@@ -867,6 +867,25 @@ fn remove_redundant() {
         assert_fuzzy_eq!(result[0], PlineVertex::new(-0.5, 0.0, 1.0));
         assert_fuzzy_eq!(result[1], PlineVertex::new(0.5, 0.0, 1.0));
     }
+
+    {
+        // n equal points
+        let mut polyline1 = Polyline::with_capacity(3, false);
+        polyline1.add(0.0, 0.0, 0.0);
+        polyline1.add(0.0, 0.0, 0.0);
+        polyline1.add(0.0, 0.0, 0.0);
+        let mut polyline2 = Polyline::with_capacity(3, false);
+        polyline2.add(1.0, 1.0, 0.0);
+        polyline2.add(1.0, 1.0, 0.0);
+        polyline2.add(1.0, 1.0, 1.0);
+
+        let r1 = polyline1.remove_redundant(1e-5).unwrap();
+        let r2 = polyline2.remove_redundant(1e-5).unwrap();
+        assert_eq!(r1.vertex_count(), 1);
+        assert_eq!(r2.vertex_count(), 1);
+        assert_fuzzy_eq!(r1[0], PlineVertex::new(0.0, 0.0, 0.0));
+        assert_fuzzy_eq!(r2[0], PlineVertex::new(1.0, 1.0, 1.0));
+    }
 }
 
 #[test]


### PR DESCRIPTION
remove_redundant panics on polyline with equal points
for example [(0, 0, 0), (0, 0, 0), (0, 0, 0)]