### PR TITLE
Cleaned up and simplified pline spatial index creation

### DIFF
--- a/cavalier_contours/src/polyline/internal/pline_boolean.rs
+++ b/cavalier_contours/src/polyline/internal/pline_boolean.rs
@@ -736,7 +736,7 @@ where
     let pline1_aabb_index = if let Some(x) = options.pline1_aabb_index {
         x
     } else {
-        constructed_index = pline1.create_approx_aabb_index().unwrap();
+        constructed_index = pline1.create_approx_aabb_index();
         &constructed_index
     };
 

--- a/cavalier_contours/src/polyline/internal/pline_intersects.rs
+++ b/cavalier_contours/src/polyline/internal/pline_intersects.rs
@@ -323,7 +323,7 @@ where
     let pline1_aabb_index = if let Some(x) = options.pline1_aabb_index {
         x
     } else {
-        constructed_index1 = pline1.create_approx_aabb_index().unwrap();
+        constructed_index1 = pline1.create_approx_aabb_index();
         &constructed_index1
     };
 
@@ -888,15 +888,13 @@ mod global_self_intersect_tests {
         let mut pline = Polyline::new_closed();
         pline.add(0.0, 0.0, 1.0);
         pline.add(2.0, 0.0, 1.0);
-        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index().unwrap());
+        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index());
         assert_eq!(intrs.basic_intersects.len(), 0);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
 
         let pline_as_lines = pline.arcs_to_approx_lines(1e-2).unwrap();
-        let intrs = global_self_intersects(
-            &pline_as_lines,
-            &pline_as_lines.create_approx_aabb_index().unwrap(),
-        );
+        let intrs =
+            global_self_intersects(&pline_as_lines, &pline_as_lines.create_approx_aabb_index());
 
         assert_eq!(intrs.basic_intersects.len(), 0);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
@@ -907,7 +905,7 @@ mod global_self_intersect_tests {
         let mut pline = Polyline::new_closed();
         pline.add(0.0, 0.0, 1.0);
         pline.add(2.0, 0.0, -1.0);
-        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index().unwrap());
+        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index());
         assert_eq!(intrs.basic_intersects.len(), 0);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
     }
@@ -919,16 +917,14 @@ mod global_self_intersect_tests {
         pline.add(0.0, 0.0, 1.0);
         pline.add(2.0, 0.0, 1.0);
         pline.add(0.0, 0.0, 0.0);
-        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index().unwrap());
+        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index());
         assert_eq!(intrs.basic_intersects.len(), 0);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
 
         // self intersect at end point is returned since not local self intersect
         let pline_as_lines = pline.arcs_to_approx_lines(1e-2).unwrap();
-        let intrs = global_self_intersects(
-            &pline_as_lines,
-            &pline_as_lines.create_approx_aabb_index().unwrap(),
-        );
+        let intrs =
+            global_self_intersects(&pline_as_lines, &pline_as_lines.create_approx_aabb_index());
 
         assert_eq!(intrs.basic_intersects.len(), 1);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
@@ -950,7 +946,7 @@ mod global_self_intersect_tests {
         pline.add(2.0, 0.0, bulge_from_angle(std::f64::consts::FRAC_PI_2));
         pline.add(1.0, 1.0, bulge_from_angle(std::f64::consts::FRAC_PI_2));
         pline.add(0.0, 0.0, 0.0);
-        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index().unwrap());
+        let intrs = global_self_intersects(&pline, &pline.create_approx_aabb_index());
         assert_eq!(intrs.basic_intersects.len(), 1);
         assert_eq!(intrs.overlapping_intersects.len(), 0);
         assert_eq!(intrs.basic_intersects[0].start_index1, 0);

--- a/cavalier_contours/src/polyline/internal/pline_offset.rs
+++ b/cavalier_contours/src/polyline/internal/pline_offset.rs
@@ -710,7 +710,7 @@ where
     let pos_equal_eps = options.pos_equal_eps;
     let offset_dist_eps = options.offset_dist_eps;
 
-    let raw_offset_index = raw_offset_polyline.create_approx_aabb_index().unwrap();
+    let raw_offset_index = raw_offset_polyline.create_approx_aabb_index();
     let self_intrs =
         all_self_intersects_as_basic(raw_offset_polyline, &raw_offset_index, false, pos_equal_eps);
 
@@ -1038,7 +1038,7 @@ where
     let pos_equal_eps = options.pos_equal_eps;
     let offset_dist_eps = options.offset_dist_eps;
 
-    let raw_offset_index = raw_offset_polyline.create_approx_aabb_index().unwrap();
+    let raw_offset_index = raw_offset_polyline.create_approx_aabb_index();
 
     let self_intrs =
         all_self_intersects_as_basic(raw_offset_polyline, &raw_offset_index, false, pos_equal_eps);
@@ -1489,7 +1489,7 @@ where
     let index = if let Some(x) = options.aabb_index {
         x
     } else {
-        constructed_index = polyline.create_approx_aabb_index().unwrap();
+        constructed_index = polyline.create_approx_aabb_index();
         &constructed_index
     };
 

--- a/cavalier_contours_ffi/src/lib.rs
+++ b/cavalier_contours_ffi/src/lib.rs
@@ -981,7 +981,6 @@ pub unsafe extern "C" fn cavc_pline_boolean(
 ///
 /// ## Specific Error Codes
 /// * 1 = `pline` is null.
-/// * 2 = `pline` vertex count is less than 2.
 ///
 /// # Safety
 ///
@@ -999,13 +998,9 @@ pub unsafe extern "C" fn cavc_pline_create_approx_aabbindex(
             return 1;
         }
 
-        match (*pline).0.create_approx_aabb_index() {
-            Some(result) => {
-                aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
-                0
-            }
-            None => 2,
-        }
+        let result = (*pline).0.create_approx_aabb_index();
+        aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        0
     })
 }
 
@@ -1013,7 +1008,6 @@ pub unsafe extern "C" fn cavc_pline_create_approx_aabbindex(
 ///
 /// ## Specific Error Codes
 /// * 1 = `pline` is null.
-/// * 2 = `pline` vertex count is less than 2.
 ///
 /// # Safety
 ///
@@ -1031,13 +1025,9 @@ pub unsafe extern "C" fn cavc_pline_create_aabbindex(
             return 1;
         }
 
-        match (*pline).0.create_aabb_index() {
-            Some(result) => {
-                aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
-                0
-            }
-            None => 2,
-        }
+        let result = (*pline).0.create_aabb_index();
+        aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        0
     })
 }
 


### PR DESCRIPTION
PlineSource::create_aabb_index and PlineSource::create_approx_aabb_index no longer return an Option since having less than 2 vertexes will now create an empty aabb spatial index. Added docs and made panic message clear regarding case where Self::Num fails to cast to/from a u16 which is required for constructing the index (this should not come up in practice because Self::Num type is decided at compile time so I decided not to return a result and instead just panic with a clear error message).