### PR TITLE
Update to Rust 2024 edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.72.0
+          toolchain: 1.85.0
           components: rustfmt, clippy
 
       - name: Check formatting

--- a/cavalier_contours/Cargo.toml
+++ b/cavalier_contours/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Buck McCready <jbuckmccready@gmail.com>"]
 categories = ["algorithms", "data-structures", "graphics", "mathematics"]
 description = "2D polyline/shape library for offsetting, combining, etc."
-edition = "2021"
+edition = "2024"
 keywords = ["algorithm", "2d", "computational", "geometry", "spatial"]
 license = "MIT OR Apache-2.0"
 name = "cavalier_contours"

--- a/cavalier_contours/src/core/math/base_math.rs
+++ b/cavalier_contours/src/core/math/base_math.rs
@@ -16,11 +16,7 @@ pub fn min_max<T>(v1: T, v2: T) -> (T, T)
 where
     T: PartialOrd,
 {
-    if v1 < v2 {
-        (v1, v2)
-    } else {
-        (v2, v1)
-    }
+    if v1 < v2 { (v1, v2) } else { (v2, v1) }
 }
 
 /// Normalize radians to be between `0` and `2PI`, e.g. `-PI/4` becomes `7PI/4` and `5PI` becomes
@@ -96,11 +92,7 @@ where
     T: Real,
 {
     let diff = delta_angle(angle1, angle2);
-    if negative {
-        -diff.abs()
-    } else {
-        diff.abs()
-    }
+    if negative { -diff.abs() } else { diff.abs() }
 }
 
 /// Tests if `test_angle` is between a `start_angle` and `end_angle`.

--- a/cavalier_contours/src/core/math/line_circle_intersect.rs
+++ b/cavalier_contours/src/core/math/line_circle_intersect.rs
@@ -1,5 +1,5 @@
-use super::base_math::min_max;
 use super::Vector2;
+use super::base_math::min_max;
 use crate::core::math::parametric_from_point;
 use crate::core::traits::Real;
 

--- a/cavalier_contours/src/core/math/line_line_intersect.rs
+++ b/cavalier_contours/src/core/math/line_line_intersect.rs
@@ -1,4 +1,4 @@
-use super::{base_math::parametric_from_point, Vector2};
+use super::{Vector2, base_math::parametric_from_point};
 use crate::core::traits::Real;
 
 /// Holds the result of finding the intersect between two line segments.

--- a/cavalier_contours/src/core/math/mod.rs
+++ b/cavalier_contours/src/core/math/mod.rs
@@ -6,7 +6,7 @@ mod line_line_intersect;
 mod vector2;
 
 pub use base_math::*;
-pub use circle_circle_intersect::{circle_circle_intr, CircleCircleIntr};
-pub use line_circle_intersect::{line_circle_intr, LineCircleIntr};
-pub use line_line_intersect::{line_line_intr, LineLineIntr};
+pub use circle_circle_intersect::{CircleCircleIntr, circle_circle_intr};
+pub use line_circle_intersect::{LineCircleIntr, line_circle_intr};
+pub use line_line_intersect::{LineLineIntr, line_line_intr};
 pub use vector2::Vector2;

--- a/cavalier_contours/src/core/math/vector2.rs
+++ b/cavalier_contours/src/core/math/vector2.rs
@@ -114,7 +114,7 @@ where
 #[cfg(feature = "serde")]
 mod serde_impl {
     use super::Vector2;
-    use serde::{ser::SerializeTuple, Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, ser::SerializeTuple};
 
     impl<T> Serialize for Vector2<T>
     where

--- a/cavalier_contours/src/polyline/internal/pline_boolean.rs
+++ b/cavalier_contours/src/polyline/internal/pline_boolean.rs
@@ -1,15 +1,15 @@
 use crate::{
     core::math::dist_squared,
     polyline::{
-        seg_midpoint, seg_split_at_point, BooleanOp, BooleanPlineSlice, BooleanResult,
-        BooleanResultInfo, BooleanResultPline, FindIntersectsOptions, PlineBasicIntersect,
-        PlineBooleanOptions, PlineCreation, PlineSource, PlineViewData,
+        BooleanOp, BooleanPlineSlice, BooleanResult, BooleanResultInfo, BooleanResultPline,
+        FindIntersectsOptions, PlineBasicIntersect, PlineBooleanOptions, PlineCreation,
+        PlineSource, PlineViewData, seg_midpoint, seg_split_at_point,
     },
 };
 use std::collections::BTreeMap;
 
 use super::pline_intersects::{
-    find_intersects, sort_and_join_overlapping_intersects, OverlappingSlice,
+    OverlappingSlice, find_intersects, sort_and_join_overlapping_intersects,
 };
 use crate::{
     core::{math::Vector2, traits::Real},
@@ -594,10 +594,12 @@ where
 
     let mut close_pline = |mut pline: O, subslices: Vec<BooleanPlineSlice<T>>| {
         // sanity assert (start should connect back with end)
-        debug_assert!(pline
-            .at(0)
-            .pos()
-            .fuzzy_eq_eps(pline.last().unwrap().pos(), pos_equal_eps));
+        debug_assert!(
+            pline
+                .at(0)
+                .pos()
+                .fuzzy_eq_eps(pline.last().unwrap().pos(), pos_equal_eps)
+        );
 
         if pline.vertex_count() < 3 {
             // skip slice in case of just two vertexes on top of each other

--- a/cavalier_contours/src/polyline/internal/pline_intersects.rs
+++ b/cavalier_contours/src/polyline/internal/pline_intersects.rs
@@ -1,14 +1,14 @@
 use crate::{
     core::{
-        math::{dist_squared, Vector2},
-        traits::{ControlFlow, Real},
         Control,
+        math::{Vector2, dist_squared},
+        traits::{ControlFlow, Real},
     },
     polyline::{
-        pline_seg_intr, seg_fast_approx_bounding_box, seg_split_at_point, seg_tangent_vector,
         FindIntersectsOptions, PlineBasicIntersect, PlineIntersectVisitor,
         PlineIntersectsCollection, PlineOverlappingIntersect, PlineSegIntr, PlineSource, PlineView,
-        PlineViewData,
+        PlineViewData, pline_seg_intr, seg_fast_approx_bounding_box, seg_split_at_point,
+        seg_tangent_vector,
     },
 };
 use static_aabb2d_index as aabb_index;

--- a/cavalier_contours/src/polyline/internal/pline_offset.rs
+++ b/cavalier_contours/src/polyline/internal/pline_offset.rs
@@ -1,17 +1,18 @@
 use crate::{
     core::{
         math::{
-            angle, bulge_from_angle, circle_circle_intr, delta_angle, delta_angle_signed,
-            dist_squared, line_circle_intr, line_line_intr, point_from_parametric,
-            point_within_arc_sweep, CircleCircleIntr, LineCircleIntr, LineLineIntr, Vector2,
+            CircleCircleIntr, LineCircleIntr, LineLineIntr, Vector2, angle, bulge_from_angle,
+            circle_circle_intr, delta_angle, delta_angle_signed, dist_squared, line_circle_intr,
+            line_line_intr, point_from_parametric, point_within_arc_sweep,
         },
         traits::Real,
     },
     polyline::{
+        FindIntersectsOptions, PlineCreation, PlineOffsetOptions, PlineSegIntr, PlineSource,
+        PlineSourceMut, PlineVertex, PlineViewData,
         internal::pline_intersects::{all_self_intersects_as_basic, find_intersects},
         pline_seg_intr, seg_arc_radius_and_center, seg_closest_point, seg_fast_approx_bounding_box,
-        seg_midpoint, FindIntersectsOptions, PlineCreation, PlineOffsetOptions, PlineSegIntr,
-        PlineSource, PlineSourceMut, PlineVertex, PlineViewData,
+        seg_midpoint,
     },
 };
 use static_aabb2d_index::{Control, StaticAABB2DIndex, StaticAABB2DIndexBuilder};

--- a/cavalier_contours/src/polyline/pline_seg.rs
+++ b/cavalier_contours/src/polyline/pline_seg.rs
@@ -1,9 +1,9 @@
 use super::PlineVertex;
 use crate::core::{
     math::{
-        angle, angle_is_within_sweep, bulge_from_angle, delta_angle, delta_angle_signed,
+        Vector2, angle, angle_is_within_sweep, bulge_from_angle, delta_angle, delta_angle_signed,
         dist_squared, line_seg_closest_point, midpoint, min_max, point_on_circle,
-        point_within_arc_sweep, Vector2,
+        point_within_arc_sweep,
     },
     traits::Real,
 };

--- a/cavalier_contours/src/polyline/pline_seg_intersect.rs
+++ b/cavalier_contours/src/polyline/pline_seg_intersect.rs
@@ -1,11 +1,11 @@
-use super::pline_seg::seg_arc_radius_and_center;
 use super::PlineVertex;
+use super::pline_seg::seg_arc_radius_and_center;
 use crate::core::{
     math::Vector2,
     math::{
-        angle, angle_from_bulge, angle_is_within_sweep, circle_circle_intr, delta_angle,
-        dist_squared, line_circle_intr, line_line_intr, normalize_radians, point_from_parametric,
-        point_within_arc_sweep, CircleCircleIntr, LineCircleIntr, LineLineIntr,
+        CircleCircleIntr, LineCircleIntr, LineLineIntr, angle, angle_from_bulge,
+        angle_is_within_sweep, circle_circle_intr, delta_angle, dist_squared, line_circle_intr,
+        line_line_intr, normalize_radians, point_from_parametric, point_within_arc_sweep,
     },
     traits::Real,
 };
@@ -126,11 +126,7 @@ where
                 p,
                 pos_equal_eps,
             );
-            if within_sweep {
-                Some(p)
-            } else {
-                None
-            }
+            if within_sweep { Some(p) } else { None }
         };
 
         // Note if intersect is detected we check if the line segment starts or ends on the arc

--- a/cavalier_contours/src/polyline/pline_types.rs
+++ b/cavalier_contours/src/polyline/pline_types.rs
@@ -1,6 +1,6 @@
 //! Supporting public types used in the core polyline trait methods.
 
-use super::{internal::pline_intersects::OverlappingSlice, PlineVertex, PlineView, PlineViewData};
+use super::{PlineVertex, PlineView, PlineViewData, internal::pline_intersects::OverlappingSlice};
 use crate::{
     core::{
         math::Vector2,

--- a/cavalier_contours/src/polyline/pline_vertex.rs
+++ b/cavalier_contours/src/polyline/pline_vertex.rs
@@ -34,7 +34,7 @@ where
 #[cfg(feature = "serde")]
 mod serde_impl {
     use super::PlineVertex;
-    use serde::{ser::SerializeTuple, Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, ser::SerializeTuple};
 
     impl<T> Serialize for PlineVertex<T>
     where

--- a/cavalier_contours/src/polyline/pline_view.rs
+++ b/cavalier_contours/src/polyline/pline_view.rs
@@ -1,12 +1,12 @@
 use crate::{
     core::{
-        math::{dist_squared, Vector2},
+        math::{Vector2, dist_squared},
         traits::Real,
     },
     polyline::seg_split_at_point,
 };
 
-use super::{seg_closest_point, PlineSource, PlineVertex, Polyline};
+use super::{PlineSource, PlineVertex, Polyline, seg_closest_point};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -303,7 +303,8 @@ where
     where
         P: PlineSource<Num = T> + ?Sized,
     {
-        assert!(traverse_count != 0,
+        assert!(
+            traverse_count != 0,
             "traverse_count must be greater than 1, use different constructor if view is all on one segment"
         );
 

--- a/cavalier_contours/src/polyline/traits.rs
+++ b/cavalier_contours/src/polyline/traits.rs
@@ -1,20 +1,22 @@
 use static_aabb2d_index::{
-    IndexableNum, StaticAABB2DIndex, StaticAABB2DIndexBuildError, StaticAABB2DIndexBuilder, AABB,
+    AABB, IndexableNum, StaticAABB2DIndex, StaticAABB2DIndexBuildError, StaticAABB2DIndexBuilder,
 };
 
 use crate::{
     core::{
         math::{
-            angle, angle_from_bulge, bulge_from_angle, delta_angle, dist_squared, is_left,
-            is_left_or_equal, point_on_circle, Vector2,
+            Vector2, angle, angle_from_bulge, bulge_from_angle, delta_angle, dist_squared, is_left,
+            is_left_or_equal, point_on_circle,
         },
         traits::{ControlFlow, FuzzyEq, FuzzyOrd, Real},
     },
-    polyline::{seg_arc_radius_and_center, SelfIntersectsInclude},
+    polyline::{SelfIntersectsInclude, seg_arc_radius_and_center},
 };
 
 use super::{
-    arc_seg_bounding_box,
+    BooleanOp, BooleanResult, ClosestPointResult, FindIntersectsOptions, PlineBooleanOptions,
+    PlineIntersectVisitor, PlineIntersectsCollection, PlineOffsetOptions, PlineOrientation,
+    PlineSelfIntersectOptions, PlineVertex, arc_seg_bounding_box,
     internal::{
         pline_boolean::polyline_boolean,
         pline_intersects::{
@@ -23,14 +25,12 @@ use super::{
         pline_offset::parallel_offset,
     },
     seg_bounding_box, seg_closest_point, seg_fast_approx_bounding_box, seg_length,
-    seg_split_at_point, BooleanOp, BooleanResult, ClosestPointResult, FindIntersectsOptions,
-    PlineBooleanOptions, PlineIntersectVisitor, PlineIntersectsCollection, PlineOffsetOptions,
-    PlineOrientation, PlineSelfIntersectOptions, PlineVertex,
+    seg_split_at_point,
 };
-use num_traits::cast::NumCast;
 use num_traits::One;
 use num_traits::ToPrimitive;
 use num_traits::Zero;
+use num_traits::cast::NumCast;
 
 /// Trait representing a readonly source of polyline data. This trait has all the methods and
 /// operations that can be performed on a readonly polyline.
@@ -141,11 +141,7 @@ pub trait PlineSource {
     #[inline]
     fn next_wrapping_index(&self, i: usize) -> usize {
         let next = i + 1;
-        if next >= self.vertex_count() {
-            0
-        } else {
-            next
-        }
+        if next >= self.vertex_count() { 0 } else { next }
     }
 
     /// Returns the previous wrapping vertex index for the polyline.
@@ -223,11 +219,7 @@ pub trait PlineSource {
         debug_assert!(offset <= vc, "offset wraps multiple times");
 
         let sum = start_index + offset;
-        if sum < vc {
-            sum
-        } else {
-            sum - vc
-        }
+        if sum < vc { sum } else { sum - vc }
     }
 
     /// Compute the XY extents of the polyline.

--- a/cavalier_contours/src/shape_algorithms/mod.rs
+++ b/cavalier_contours/src/shape_algorithms/mod.rs
@@ -4,13 +4,13 @@ use static_aabb2d_index::{StaticAABB2DIndex, StaticAABB2DIndexBuilder};
 
 use crate::{
     core::{
-        math::{dist_squared, Vector2},
+        math::{Vector2, dist_squared},
         traits::Real,
     },
     polyline::{
-        internal::pline_offset::point_valid_for_offset, seg_midpoint, FindIntersectsOptions,
-        PlineBasicIntersect, PlineOffsetOptions, PlineOrientation, PlineSource, PlineSourceMut,
-        PlineViewData, Polyline,
+        FindIntersectsOptions, PlineBasicIntersect, PlineOffsetOptions, PlineOrientation,
+        PlineSource, PlineSourceMut, PlineViewData, Polyline,
+        internal::pline_offset::point_valid_for_offset, seg_midpoint,
     },
 };
 

--- a/cavalier_contours/tests/test_circle_circle_intersect.rs
+++ b/cavalier_contours/tests/test_circle_circle_intersect.rs
@@ -1,4 +1,4 @@
-use cavalier_contours::core::math::{circle_circle_intr, CircleCircleIntr::*, Vector2};
+use cavalier_contours::core::math::{CircleCircleIntr::*, Vector2, circle_circle_intr};
 
 macro_rules! assert_case_eq {
     ($left:expr, $right:expr) => {

--- a/cavalier_contours/tests/test_line_circle_intersect.rs
+++ b/cavalier_contours/tests/test_line_circle_intersect.rs
@@ -1,5 +1,5 @@
 use cavalier_contours::core::{
-    math::{line_circle_intr, LineCircleIntr::*, Vector2},
+    math::{LineCircleIntr::*, Vector2, line_circle_intr},
     traits::FuzzyEq,
 };
 

--- a/cavalier_contours/tests/test_line_line_intersect.rs
+++ b/cavalier_contours/tests/test_line_line_intersect.rs
@@ -1,5 +1,5 @@
 use cavalier_contours::core::{
-    math::{line_line_intr, LineLineIntr::*, Vector2},
+    math::{LineLineIntr::*, Vector2, line_line_intr},
     traits::FuzzyEq,
 };
 use std::f64::consts::{FRAC_PI_2, FRAC_PI_3, FRAC_PI_4, FRAC_PI_6, FRAC_PI_8};

--- a/cavalier_contours/tests/test_pline_basics.rs
+++ b/cavalier_contours/tests/test_pline_basics.rs
@@ -1,13 +1,13 @@
 use cavalier_contours::{
     assert_fuzzy_eq,
     core::{
-        math::{bulge_from_angle, Vector2},
+        math::{Vector2, bulge_from_angle},
         traits::FuzzyEq,
     },
     pline_closed, pline_open,
     polyline::{
-        seg_length, PlineCreation, PlineSource, PlineSourceMut, PlineVertex, PlineViewData,
-        Polyline,
+        PlineCreation, PlineSource, PlineSourceMut, PlineVertex, PlineViewData, Polyline,
+        seg_length,
     },
 };
 use std::f64::consts::{PI, TAU};
@@ -899,17 +899,21 @@ fn rotate_start() {
     {
         // empty polyline
         let polyline = Polyline::new_closed();
-        assert!(polyline
-            .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
-            .is_none());
+        assert!(
+            polyline
+                .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
+                .is_none()
+        );
     }
 
     {
         // single vertex polyline
         let polyline = pline_closed![(1.0, 0.0, 0.0)];
-        assert!(polyline
-            .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
-            .is_none());
+        assert!(
+            polyline
+                .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
+                .is_none()
+        );
     }
 
     {
@@ -920,9 +924,11 @@ fn rotate_start() {
             (1.0, 1.0, 0.2),
             (0.0, 1.0, -0.1),
         ];
-        assert!(polyline
-            .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
-            .is_none());
+        assert!(
+            polyline
+                .rotate_start(0, Vector2::new(0.0, 0.0), 1e-5)
+                .is_none()
+        );
     }
 
     {

--- a/cavalier_contours/tests/test_pline_boolean.rs
+++ b/cavalier_contours/tests/test_pline_boolean.rs
@@ -5,8 +5,8 @@ use cavalier_contours::polyline::{
     PlineCreation, PlineSource, PlineSourceMut, Polyline,
 };
 use test_utils::{
-    create_property_set, property_sets_match, property_sets_match_abs_a, ModifiedPlineSet,
-    ModifiedPlineSetVisitor, ModifiedPlineState, PlineProperties,
+    ModifiedPlineSet, ModifiedPlineSetVisitor, ModifiedPlineState, PlineProperties,
+    create_property_set, property_sets_match, property_sets_match_abs_a,
 };
 
 fn create_boolean_property_set(polylines: &[BooleanResultPline<Polyline>]) -> Vec<PlineProperties> {
@@ -239,7 +239,7 @@ struct SameBooleanTestVisitor<'a> {
     other_set: ModifiedPlineSet<'a>,
 }
 
-impl<'a> ModifiedPlineSetVisitor for SameBooleanTestVisitor<'a> {
+impl ModifiedPlineSetVisitor for SameBooleanTestVisitor<'_> {
     fn visit(&mut self, modified_pline: Polyline<f64>, pline_state: ModifiedPlineState) {
         // test every combination of direction and index position cycle
         self.other_set

--- a/cavalier_contours/tests/test_pline_parallel_offset.rs
+++ b/cavalier_contours/tests/test_pline_parallel_offset.rs
@@ -2,8 +2,8 @@ mod test_utils;
 
 use cavalier_contours::polyline::{PlineOffsetOptions, PlineSource, Polyline};
 use test_utils::{
-    create_property_set, property_sets_match, ModifiedPlineSet, ModifiedPlineSetVisitor,
-    ModifiedPlineState, PlineProperties,
+    ModifiedPlineSet, ModifiedPlineSetVisitor, ModifiedPlineState, PlineProperties,
+    create_property_set, property_sets_match,
 };
 
 fn offset_into_properties_set(
@@ -33,7 +33,7 @@ struct PlineOffsetTestVisitor<'a> {
     handle_self_intersects: bool,
 }
 
-impl<'a> ModifiedPlineSetVisitor for PlineOffsetTestVisitor<'a> {
+impl ModifiedPlineSetVisitor for PlineOffsetTestVisitor<'_> {
     fn visit(&mut self, modified_pline: Polyline<f64>, pline_state: ModifiedPlineState) {
         let offset_results = offset_into_properties_set(
             &modified_pline,
@@ -55,10 +55,10 @@ impl<'a> ModifiedPlineSetVisitor for PlineOffsetTestVisitor<'a> {
                 true,
             );
             assert!(
-            property_sets_match(&offset_results, self.expected_properties_set),
-            "property sets do not match with handle_self_intersects set to true, modified state: {:?}",
-            pline_state
-        );
+                property_sets_match(&offset_results, self.expected_properties_set),
+                "property sets do not match with handle_self_intersects set to true, modified state: {:?}",
+                pline_state
+            );
         }
     }
 }

--- a/cavalier_contours/tests/test_pline_seg_intersect.rs
+++ b/cavalier_contours/tests/test_pline_seg_intersect.rs
@@ -1,6 +1,6 @@
 use cavalier_contours::{
-    core::math::{bulge_from_angle, Vector2},
-    polyline::{pline_seg_intr, PlineSegIntr::*, PlineVertex},
+    core::math::{Vector2, bulge_from_angle},
+    polyline::{PlineSegIntr::*, PlineVertex, pline_seg_intr},
 };
 use std::f64::consts::FRAC_PI_2;
 

--- a/cavalier_contours/tests/test_pline_view.rs
+++ b/cavalier_contours/tests/test_pline_view.rs
@@ -2,7 +2,7 @@ use std::f64::consts::{FRAC_PI_2, FRAC_PI_3, PI};
 
 use cavalier_contours::{
     assert_fuzzy_eq,
-    core::math::{bulge_from_angle, point_on_circle, Vector2},
+    core::math::{Vector2, bulge_from_angle, point_on_circle},
     pline_closed, pline_open,
     polyline::{PlineCreation, PlineSource, PlineSourceMut, PlineVertex, PlineViewData, Polyline},
 };

--- a/cavalier_contours/tests/test_shape_parallel_offset.rs
+++ b/cavalier_contours/tests/test_shape_parallel_offset.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 
 use cavalier_contours::{polyline::Polyline, shape_algorithms::Shape};
-use test_utils::{create_property_set, PlineProperties};
+use test_utils::{PlineProperties, create_property_set};
 
 use crate::test_utils::property_sets_match;
 

--- a/cavalier_contours/tests/test_utils/pline_test_properties.rs
+++ b/cavalier_contours/tests/test_utils/pline_test_properties.rs
@@ -52,11 +52,7 @@ impl PlineProperties {
         let pline = rr.as_ref().unwrap_or(pline);
         let area = {
             let a = pline.area();
-            if invert_area {
-                -a
-            } else {
-                a
-            }
+            if invert_area { -a } else { a }
         };
 
         Self {

--- a/cavalier_contours_ffi/Cargo.toml
+++ b/cavalier_contours_ffi/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Buck McCready <jbuckmccready@gmail.com>"]
 categories = ["algorithms", "data-structures", "graphics", "mathematics"]
 description = "C foreign function interface for the cavalier_contours crate"
-edition = "2021"
+edition = "2024"
 keywords = ["algorithm", "2d", "computational", "geometry", "spatial"]
 license = "MIT OR Apache-2.0"
 name = "cavalier_contours_ffi"

--- a/cavalier_contours_ffi/src/lib.rs
+++ b/cavalier_contours_ffi/src/lib.rs
@@ -91,8 +91,9 @@ impl cavc_pline_parallel_offset_o {
     ///
     /// `aabb_index` field must be null or a valid pointer to a [cavc_aabbindex].
     pub unsafe fn to_internal(&self) -> PlineOffsetOptions<f64> {
+        let aabb_index = unsafe { self.aabb_index.as_ref().map(|w| &w.0) };
         PlineOffsetOptions {
-            aabb_index: self.aabb_index.as_ref().map(|w| &w.0),
+            aabb_index,
             pos_equal_eps: self.pos_equal_eps,
             slice_join_eps: self.slice_join_eps,
             offset_dist_eps: self.offset_dist_eps,
@@ -122,7 +123,7 @@ impl Default for cavc_pline_parallel_offset_o {
 /// # Safety
 ///
 /// `options` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_parallel_offset_o_init(
     options: *mut cavc_pline_parallel_offset_o,
@@ -132,7 +133,9 @@ pub unsafe extern "C" fn cavc_pline_parallel_offset_o_init(
             return 1;
         }
 
-        options.write(Default::default());
+        unsafe {
+            options.write(Default::default());
+        }
         0
     })
 }
@@ -152,8 +155,9 @@ impl cavc_pline_boolean_o {
     ///
     /// `pline1_aabb_index` field must be null or a valid pointer to a [cavc_aabbindex].
     pub unsafe fn to_internal(&self) -> PlineBooleanOptions<f64> {
+        let pline1_aabb_index = unsafe { self.pline1_aabb_index.as_ref().map(|w| &w.0) };
         PlineBooleanOptions {
-            pline1_aabb_index: self.pline1_aabb_index.as_ref().map(|w| &w.0),
+            pline1_aabb_index,
             pos_equal_eps: self.pos_equal_eps,
         }
     }
@@ -177,7 +181,7 @@ impl Default for cavc_pline_boolean_o {
 /// # Safety
 ///
 /// `options` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_boolean_o_init(options: *mut cavc_pline_boolean_o) -> i32 {
     ffi_catch_unwind!({
@@ -185,7 +189,9 @@ pub unsafe extern "C" fn cavc_pline_boolean_o_init(options: *mut cavc_pline_bool
             return 1;
         }
 
-        options.write(Default::default());
+        unsafe {
+            options.write(Default::default());
+        }
         0
     })
 }
@@ -237,7 +243,7 @@ impl cavc_plinelist {
 /// `vertexes` may be null if `n_vertexes` is 0 or must point to a valid contiguous buffer of
 /// [cavc_vertex] with length of at least `n_vertexes`.
 /// `pline` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_create(
     vertexes: *const cavc_vertex,
@@ -252,14 +258,16 @@ pub unsafe extern "C" fn cavc_pline_create(
         }
 
         if !vertexes.is_null() && n_vertexes != 0 {
-            let data = slice::from_raw_parts(vertexes, n_vertexes as usize);
+            let data = unsafe { slice::from_raw_parts(vertexes, n_vertexes as usize) };
             result.reserve(data.len());
             for v in data {
                 result.add(v.x, v.y, v.bulge);
             }
         }
 
-        pline.write(Box::into_raw(Box::new(cavc_pline(result))));
+        unsafe {
+            pline.write(Box::into_raw(Box::new(cavc_pline(result))));
+        }
         0
     })
 }
@@ -272,10 +280,12 @@ pub unsafe extern "C" fn cavc_pline_create(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not already been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cavc_pline_f(pline: *mut cavc_pline) {
     if !pline.is_null() {
-        drop(Box::from_raw(pline))
+        unsafe {
+            drop(Box::from_raw(pline));
+        }
     }
 }
 
@@ -290,7 +300,7 @@ pub unsafe extern "C" fn cavc_pline_f(pline: *mut cavc_pline) {
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_reserve(pline: *mut cavc_pline, additional: u32) -> i32 {
     ffi_catch_unwind!({
@@ -298,7 +308,9 @@ pub unsafe extern "C" fn cavc_pline_reserve(pline: *mut cavc_pline, additional: 
             return 1;
         }
 
-        (*pline).0.reserve(additional as usize);
+        unsafe {
+            (*pline).0.reserve(additional as usize);
+        }
         0
     })
 }
@@ -316,7 +328,7 @@ pub unsafe extern "C" fn cavc_pline_reserve(pline: *mut cavc_pline, additional: 
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `cloned` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_clone(
     pline: *const cavc_pline,
@@ -327,7 +339,9 @@ pub unsafe extern "C" fn cavc_pline_clone(
             return 1;
         }
 
-        cloned.write(Box::into_raw(Box::new(cavc_pline((*pline).0.clone()))));
+        unsafe {
+            cloned.write(Box::into_raw(Box::new(cavc_pline((*pline).0.clone()))));
+        }
         0
     })
 }
@@ -345,7 +359,7 @@ pub unsafe extern "C" fn cavc_pline_clone(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `is_closed` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_get_is_closed(
     pline: *const cavc_pline,
@@ -355,7 +369,9 @@ pub unsafe extern "C" fn cavc_pline_get_is_closed(
         if pline.is_null() {
             return 1;
         }
-        is_closed.write((*pline).0.is_closed() as u8);
+        unsafe {
+            is_closed.write((*pline).0.is_closed() as u8);
+        }
         0
     })
 }
@@ -371,14 +387,16 @@ pub unsafe extern "C" fn cavc_pline_get_is_closed(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_set_is_closed(pline: *mut cavc_pline, is_closed: u8) -> i32 {
     ffi_catch_unwind!({
         if pline.is_null() {
             return 1;
         }
-        (*pline).0.set_is_closed(is_closed != 0);
+        unsafe {
+            (*pline).0.set_is_closed(is_closed != 0);
+        }
         0
     })
 }
@@ -395,7 +413,7 @@ pub unsafe extern "C" fn cavc_pline_set_is_closed(pline: *mut cavc_pline, is_clo
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `count` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_get_vertex_count(
     pline: *const cavc_pline,
@@ -408,7 +426,9 @@ pub unsafe extern "C" fn cavc_pline_get_vertex_count(
 
         // using try_from to catch odd case of polyline vertex count greater than u32::MAX to
         // prevent memory corruption/access errors but just panic as internal error if it does occur
-        count.write(u32::try_from((*pline).0.vertex_count()).unwrap());
+        unsafe {
+            count.write(u32::try_from((*pline).0.vertex_count()).unwrap());
+        }
         0
     })
 }
@@ -429,7 +449,7 @@ pub unsafe extern "C" fn cavc_pline_get_vertex_count(
 /// has not been freed.
 /// `vertex_data` must point to a buffer that is large enough to hold all the vertexes or a buffer
 /// overrun will happen.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_get_vertex_data(
     pline: *const cavc_pline,
@@ -440,8 +460,8 @@ pub unsafe extern "C" fn cavc_pline_get_vertex_data(
             return 1;
         }
 
-        let buffer = slice::from_raw_parts_mut(vertex_data, (*pline).0.vertex_count());
-        for (i, v) in (*pline).0.iter_vertexes().enumerate() {
+        let buffer = unsafe { slice::from_raw_parts_mut(vertex_data, (*pline).0.vertex_count()) };
+        for (i, v) in unsafe { (*pline).0.iter_vertexes().enumerate() } {
             buffer[i] = cavc_vertex::from_internal(v);
         }
         0
@@ -462,7 +482,7 @@ pub unsafe extern "C" fn cavc_pline_get_vertex_data(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `vertex_data` must be a valid pointer to a buffer of at least `n_vertexes` of [cavc_vertex].
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_set_vertex_data(
     pline: *mut cavc_pline,
@@ -474,12 +494,15 @@ pub unsafe extern "C" fn cavc_pline_set_vertex_data(
             return 1;
         }
 
-        (*pline).0.clear();
-        let buffer = slice::from_raw_parts(vertex_data, n_vertexes as usize);
-        (*pline).0.reserve(buffer.len());
-        for v in buffer {
-            (*pline).0.add(v.x, v.y, v.bulge);
+        unsafe {
+            (*pline).0.clear();
+            let buffer = slice::from_raw_parts(vertex_data, n_vertexes as usize);
+            (*pline).0.reserve(buffer.len());
+            for v in buffer {
+                (*pline).0.add(v.x, v.y, v.bulge);
+            }
         }
+
         0
     })
 }
@@ -493,7 +516,7 @@ pub unsafe extern "C" fn cavc_pline_set_vertex_data(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_clear(pline: *mut cavc_pline) -> i32 {
     ffi_catch_unwind!({
@@ -501,7 +524,9 @@ pub unsafe extern "C" fn cavc_pline_clear(pline: *mut cavc_pline) -> i32 {
             return 1;
         }
 
-        (*pline).0.clear();
+        unsafe {
+            (*pline).0.clear();
+        }
         0
     })
 }
@@ -515,7 +540,7 @@ pub unsafe extern "C" fn cavc_pline_clear(pline: *mut cavc_pline) -> i32 {
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_add(pline: *mut cavc_pline, x: f64, y: f64, bulge: f64) -> i32 {
     ffi_catch_unwind!({
@@ -523,7 +548,9 @@ pub unsafe extern "C" fn cavc_pline_add(pline: *mut cavc_pline, x: f64, y: f64, 
             return 1;
         }
 
-        (*pline).0.add(x, y, bulge);
+        unsafe {
+            (*pline).0.add(x, y, bulge);
+        }
         0
     })
 }
@@ -542,7 +569,7 @@ pub unsafe extern "C" fn cavc_pline_add(pline: *mut cavc_pline, x: f64, y: f64, 
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `vertex` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_get_vertex(
     pline: *const cavc_pline,
@@ -554,12 +581,15 @@ pub unsafe extern "C" fn cavc_pline_get_vertex(
             return 1;
         }
 
-        if position >= (*pline).0.vertex_count() as u32 {
-            return 2;
+        unsafe {
+            if position >= (*pline).0.vertex_count() as u32 {
+                return 2;
+            }
+
+            let v = (*pline).0[position as usize];
+            vertex.write(cavc_vertex::from_internal(v));
         }
 
-        let v = (*pline).0[position as usize];
-        vertex.write(cavc_vertex::from_internal(v));
         0
     })
 }
@@ -577,7 +607,7 @@ pub unsafe extern "C" fn cavc_pline_get_vertex(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_set_vertex(
     pline: *mut cavc_pline,
@@ -589,11 +619,14 @@ pub unsafe extern "C" fn cavc_pline_set_vertex(
             return 1;
         }
 
-        if position >= (*pline).0.vertex_count() as u32 {
-            return 2;
+        unsafe {
+            if position >= (*pline).0.vertex_count() as u32 {
+                return 2;
+            }
+
+            (*pline).0[position as usize] = PlineVertex::new(vertex.x, vertex.y, vertex.bulge);
         }
 
-        (*pline).0[position as usize] = PlineVertex::new(vertex.x, vertex.y, vertex.bulge);
         0
     })
 }
@@ -610,7 +643,7 @@ pub unsafe extern "C" fn cavc_pline_set_vertex(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_remove(pline: *mut cavc_pline, position: u32) -> i32 {
     ffi_catch_unwind!({
@@ -618,11 +651,14 @@ pub unsafe extern "C" fn cavc_pline_remove(pline: *mut cavc_pline, position: u32
             return 1;
         }
 
-        if position as usize >= (*pline).0.vertex_count() {
-            return 2;
+        unsafe {
+            if position as usize >= (*pline).0.vertex_count() {
+                return 2;
+            }
+
+            (*pline).0.remove(position as usize);
         }
 
-        (*pline).0.remove(position as usize);
         0
     })
 }
@@ -639,7 +675,7 @@ pub unsafe extern "C" fn cavc_pline_remove(pline: *mut cavc_pline, position: u32
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `path_length` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_eval_path_length(
     pline: *const cavc_pline,
@@ -649,7 +685,9 @@ pub unsafe extern "C" fn cavc_pline_eval_path_length(
         if pline.is_null() {
             return 1;
         }
-        path_length.write((*pline).0.path_length());
+        unsafe {
+            path_length.write((*pline).0.path_length());
+        }
         0
     })
 }
@@ -666,14 +704,16 @@ pub unsafe extern "C" fn cavc_pline_eval_path_length(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `area` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_eval_area(pline: *const cavc_pline, area: *mut f64) -> i32 {
     ffi_catch_unwind!({
         if pline.is_null() {
             return 1;
         }
-        area.write((*pline).0.area());
+        unsafe {
+            area.write((*pline).0.area());
+        }
         0
     })
 }
@@ -690,7 +730,7 @@ pub unsafe extern "C" fn cavc_pline_eval_area(pline: *const cavc_pline, area: *m
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `winding_number` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_eval_wn(
     pline: *const cavc_pline,
@@ -702,7 +742,9 @@ pub unsafe extern "C" fn cavc_pline_eval_wn(
         if pline.is_null() {
             return 1;
         }
-        winding_number.write((*pline).0.winding_number(Vector2::new(x, y)));
+        unsafe {
+            winding_number.write((*pline).0.winding_number(Vector2::new(x, y)));
+        }
         0
     })
 }
@@ -716,14 +758,16 @@ pub unsafe extern "C" fn cavc_pline_eval_wn(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_invert_direction(pline: *mut cavc_pline) -> i32 {
     ffi_catch_unwind!({
         if pline.is_null() {
             return 1;
         }
-        (*pline).0.invert_direction_mut();
+        unsafe {
+            (*pline).0.invert_direction_mut();
+        }
         0
     })
 }
@@ -737,14 +781,16 @@ pub unsafe extern "C" fn cavc_pline_invert_direction(pline: *mut cavc_pline) -> 
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_scale(pline: *mut cavc_pline, scale_factor: f64) -> i32 {
     ffi_catch_unwind!({
         if pline.is_null() {
             return 1;
         }
-        (*pline).0.scale_mut(scale_factor);
+        unsafe {
+            (*pline).0.scale_mut(scale_factor);
+        }
         0
     })
 }
@@ -758,7 +804,7 @@ pub unsafe extern "C" fn cavc_pline_scale(pline: *mut cavc_pline, scale_factor: 
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_translate(
     pline: *mut cavc_pline,
@@ -769,7 +815,9 @@ pub unsafe extern "C" fn cavc_pline_translate(
         if pline.is_null() {
             return 1;
         }
-        (*pline).0.translate_mut(x_offset, y_offset);
+        unsafe {
+            (*pline).0.translate_mut(x_offset, y_offset);
+        }
         0
     })
 }
@@ -783,7 +831,7 @@ pub unsafe extern "C" fn cavc_pline_translate(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_remove_repeat_pos(
     pline: *mut cavc_pline,
@@ -793,14 +841,17 @@ pub unsafe extern "C" fn cavc_pline_remove_repeat_pos(
         if pline.is_null() {
             return 1;
         }
-        match (*pline).0.remove_repeat_pos(pos_equal_eps) {
+
+        let pline = unsafe { &mut (*pline).0 };
+
+        match pline.remove_repeat_pos(pos_equal_eps) {
             None => {
                 // do nothing (no repeat positions, leave unchanged)
                 0
             }
             Some(x) => {
                 // update self with result
-                (*pline).0 = x;
+                *pline = x;
                 0
             }
         }
@@ -816,7 +867,7 @@ pub unsafe extern "C" fn cavc_pline_remove_repeat_pos(
 ///
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_remove_redundant(
     pline: *mut cavc_pline,
@@ -826,14 +877,17 @@ pub unsafe extern "C" fn cavc_pline_remove_redundant(
         if pline.is_null() {
             return 1;
         }
-        match (*pline).0.remove_redundant(pos_equal_eps) {
+
+        let pline = unsafe { &mut (*pline).0 };
+
+        match pline.remove_redundant(pos_equal_eps) {
             None => {
                 // do nothing (no repeat positions, leave unchanged)
                 0
             }
             Some(x) => {
                 // update self with result
-                (*pline).0 = x;
+                *pline = x;
                 0
             }
         }
@@ -851,7 +905,7 @@ pub unsafe extern "C" fn cavc_pline_remove_redundant(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `min_x`, `min_y`, `max_x`, and `max_y` must all point to a valid places in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_eval_extents(
     pline: *const cavc_pline,
@@ -864,12 +918,16 @@ pub unsafe extern "C" fn cavc_pline_eval_extents(
         if pline.is_null() {
             return 1;
         }
-        match (*pline).0.extents() {
+
+        let pline = unsafe { &(*pline).0 };
+        match pline.extents() {
             Some(aabb) => {
-                min_x.write(aabb.min_x);
-                min_y.write(aabb.min_y);
-                max_x.write(aabb.max_x);
-                max_y.write(aabb.max_y);
+                unsafe {
+                    min_x.write(aabb.min_x);
+                    min_y.write(aabb.min_y);
+                    max_x.write(aabb.max_x);
+                    max_y.write(aabb.max_y);
+                }
                 0
             }
             None => 2,
@@ -889,7 +947,7 @@ pub unsafe extern "C" fn cavc_pline_eval_extents(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `result` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_parallel_offset(
     pline: *const cavc_pline,
@@ -902,15 +960,18 @@ pub unsafe extern "C" fn cavc_pline_parallel_offset(
             return 1;
         }
 
+        let pline = unsafe { &(*pline).0 };
+
         let results = if options.is_null() {
-            (*pline).0.parallel_offset(offset)
+            pline.parallel_offset(offset)
         } else {
-            (*pline)
-                .0
-                .parallel_offset_opt(offset, &(*options).to_internal())
+            let opts = unsafe { &(*options).to_internal() };
+            pline.parallel_offset_opt(offset, opts)
         };
 
-        result.write(cavc_plinelist::from_internal(results));
+        unsafe {
+            result.write(cavc_plinelist::from_internal(results));
+        }
         0
     })
 }
@@ -933,7 +994,7 @@ pub unsafe extern "C" fn cavc_pline_parallel_offset(
 /// `pline1` and `pline2` must each be null or a valid cavc_pline object that was created with
 /// [cavc_pline_create] and has not been freed.
 /// `pos_plines` and `neg_plines` must both point to different valid places in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_boolean(
     pline1: *const cavc_pline,
@@ -956,20 +1017,25 @@ pub unsafe extern "C" fn cavc_pline_boolean(
                 }
             }
         };
+
+        let pline1 = unsafe { &(*pline1).0 };
+        let pline2 = unsafe { &(*pline2).0 };
+
         let results = if options.is_null() {
-            (*pline1).0.boolean(&(*pline2).0, op)
+            pline1.boolean(pline2, op)
         } else {
-            (*pline1)
-                .0
-                .boolean_opt(&(*pline2).0, op, &(*options).to_internal())
+            let options = unsafe { &(*options).to_internal() };
+            pline1.boolean_opt(pline2, op, options)
         };
 
-        pos_plines.write(cavc_plinelist::from_internal(
-            results.pos_plines.into_iter().map(|p| p.pline),
-        ));
-        neg_plines.write(cavc_plinelist::from_internal(
-            results.neg_plines.into_iter().map(|p| p.pline),
-        ));
+        unsafe {
+            pos_plines.write(cavc_plinelist::from_internal(
+                results.pos_plines.into_iter().map(|p| p.pline),
+            ));
+            neg_plines.write(cavc_plinelist::from_internal(
+                results.neg_plines.into_iter().map(|p| p.pline),
+            ));
+        }
         0
     })
 }
@@ -984,7 +1050,7 @@ pub unsafe extern "C" fn cavc_pline_boolean(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `aabbindex` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_create_approx_aabbindex(
     pline: *const cavc_pline,
@@ -995,8 +1061,12 @@ pub unsafe extern "C" fn cavc_pline_create_approx_aabbindex(
             return 1;
         }
 
-        let result = (*pline).0.create_approx_aabb_index();
-        aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        let pline = unsafe { &(*pline).0 };
+        let result = pline.create_approx_aabb_index();
+        unsafe {
+            aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        }
+
         0
     })
 }
@@ -1011,7 +1081,7 @@ pub unsafe extern "C" fn cavc_pline_create_approx_aabbindex(
 /// `pline` must be null or a valid cavc_pline object that was created with [cavc_pline_create] and
 /// has not been freed.
 /// `aabbindex` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_pline_create_aabbindex(
     pline: *const cavc_pline,
@@ -1022,8 +1092,12 @@ pub unsafe extern "C" fn cavc_pline_create_aabbindex(
             return 1;
         }
 
-        let result = (*pline).0.create_aabb_index();
-        aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        let pline = unsafe { &(*pline).0 };
+        let result = pline.create_aabb_index();
+        unsafe {
+            aabbindex.write(Box::into_raw(Box::new(cavc_aabbindex(result))));
+        }
+
         0
     })
 }
@@ -1035,10 +1109,10 @@ pub unsafe extern "C" fn cavc_pline_create_aabbindex(
 /// # Safety
 ///
 /// `aabbindex` must be null or a valid [cavc_aabbindex] object.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cavc_aabbindex_f(aabbindex: *mut cavc_aabbindex) {
     if !aabbindex.is_null() {
-        drop(Box::from_raw(aabbindex))
+        unsafe { drop(Box::from_raw(aabbindex)) }
     }
 }
 
@@ -1052,7 +1126,7 @@ pub unsafe extern "C" fn cavc_aabbindex_f(aabbindex: *mut cavc_aabbindex) {
 ///
 /// `aabbindex` must be null or a valid [cavc_aabbindex] object.
 /// `min_x`, `min_y`, `max_x`, and `max_y` must all point to a valid places in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_aabbindex_get_extents(
     aabbindex: *const cavc_aabbindex,
@@ -1066,16 +1140,22 @@ pub unsafe extern "C" fn cavc_aabbindex_get_extents(
             return 1;
         }
 
-        if let Some(bounds) = (*aabbindex).0.bounds() {
-            min_x.write(bounds.min_x);
-            min_y.write(bounds.min_y);
-            max_x.write(bounds.max_x);
-            max_y.write(bounds.max_y);
+        let aabbindex = unsafe { &(*aabbindex).0 };
+
+        if let Some(bounds) = aabbindex.bounds() {
+            unsafe {
+                min_x.write(bounds.min_x);
+                min_y.write(bounds.min_y);
+                max_x.write(bounds.max_x);
+                max_y.write(bounds.max_y);
+            }
         } else {
-            min_x.write(f64::NAN);
-            min_y.write(f64::NAN);
-            max_x.write(f64::NAN);
-            max_y.write(f64::NAN);
+            unsafe {
+                min_x.write(f64::NAN);
+                min_y.write(f64::NAN);
+                max_x.write(f64::NAN);
+                max_y.write(f64::NAN);
+            }
         }
         0
     })
@@ -1088,10 +1168,10 @@ pub unsafe extern "C" fn cavc_aabbindex_get_extents(
 /// # Safety
 ///
 /// `plinelist` must be null or a valid [cavc_plinelist] object.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cavc_plinelist_f(plinelist: *mut cavc_plinelist) {
     if !plinelist.is_null() {
-        drop(Box::from_raw(plinelist))
+        unsafe { drop(Box::from_raw(plinelist)) }
     }
 }
 
@@ -1106,7 +1186,7 @@ pub unsafe extern "C" fn cavc_plinelist_f(plinelist: *mut cavc_plinelist) {
 ///
 /// `plinelist` must be null or a valid [cavc_plinelist] object.
 /// `count` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_plinelist_get_count(
     plinelist: *const cavc_plinelist,
@@ -1119,7 +1199,9 @@ pub unsafe extern "C" fn cavc_plinelist_get_count(
 
         // using try_from to catch odd case of polyline count greater than u32::MAX to
         // prevent memory corruption/access errors but just panic as internal error if it does occur
-        count.write(u32::try_from((*plinelist).0.len()).unwrap());
+        unsafe {
+            count.write(u32::try_from((*plinelist).0.len()).unwrap());
+        }
         0
     })
 }
@@ -1138,7 +1220,7 @@ pub unsafe extern "C" fn cavc_plinelist_get_count(
 ///
 /// `plinelist` must be null or a valid [cavc_plinelist] object.
 /// `pline` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_plinelist_get_pline(
     plinelist: *const cavc_plinelist,
@@ -1150,11 +1232,15 @@ pub unsafe extern "C" fn cavc_plinelist_get_pline(
             return 1;
         }
 
+        let plinelist = unsafe { &(*plinelist).0 };
+
         let pos = position as usize;
 
-        match (*plinelist).0.get(pos) {
+        match plinelist.get(pos) {
             Some(pl) => {
-                pline.write(*pl);
+                unsafe {
+                    pline.write(*pl);
+                }
                 0
             }
             None => 2,
@@ -1175,7 +1261,7 @@ pub unsafe extern "C" fn cavc_plinelist_get_pline(
 ///
 /// `plinelist` must be null or a valid [cavc_plinelist] object.
 /// `pline` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_plinelist_pop(
     plinelist: *mut cavc_plinelist,
@@ -1186,9 +1272,13 @@ pub unsafe extern "C" fn cavc_plinelist_pop(
             return 1;
         }
 
-        match (*plinelist).0.pop() {
+        let plinelist = unsafe { &mut (*plinelist).0 };
+
+        match plinelist.pop() {
             Some(p) => {
-                pline.write(p);
+                unsafe {
+                    pline.write(p);
+                }
                 0
             }
             None => 2,
@@ -1209,7 +1299,7 @@ pub unsafe extern "C" fn cavc_plinelist_pop(
 ///
 /// `plinelist` must be null or a valid [cavc_plinelist] object.
 /// `pline` must point to a valid place in memory to be written.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[must_use]
 pub unsafe extern "C" fn cavc_plinelist_take(
     plinelist: *mut cavc_plinelist,
@@ -1221,13 +1311,17 @@ pub unsafe extern "C" fn cavc_plinelist_take(
             return 1;
         }
 
+        let plinelist = unsafe { &mut (*plinelist).0 };
         let pos = position as usize;
 
-        if pos >= (*plinelist).0.len() {
+        if pos >= plinelist.len() {
             return 2;
         }
 
-        pline.write((*plinelist).0.remove(pos));
+        unsafe {
+            pline.write(plinelist.remove(pos));
+        }
+
         0
     })
 }

--- a/cavalier_contours_ffi/tests/test_pline.rs
+++ b/cavalier_contours_ffi/tests/test_pline.rs
@@ -141,7 +141,7 @@ fn pline_data_manipulation() {
 #[test]
 fn pline_eval_path_length() {
     let pline = create_pline(&[(0.0, 0.0, 1.0), (2.0, 0.0, 1.0)], true);
-    let mut l = std::f64::NAN;
+    let mut l = f64::NAN;
     unsafe {
         assert_eq!(cavc_pline_eval_path_length(pline, &mut l), 0);
         assert_eq!(cavc_pline_eval_path_length(ptr::null_mut(), &mut l), 1);
@@ -153,7 +153,7 @@ fn pline_eval_path_length() {
 #[test]
 fn pline_eval_area() {
     let pline = create_pline(&[(0.0, 0.0, 1.0), (2.0, 0.0, 1.0)], true);
-    let mut a = std::f64::NAN;
+    let mut a = f64::NAN;
     unsafe {
         assert_eq!(cavc_pline_eval_area(pline, &mut a), 0);
         assert_eq!(cavc_pline_eval_area(ptr::null_mut(), &mut a), 1);
@@ -338,8 +338,7 @@ fn pline_remove_redundant() {
 #[test]
 fn pline_eval_extents() {
     let pline = create_pline(&[(0.0, 0.0, 1.0), (2.0, 0.0, 1.0)], true);
-    let (mut min_x, mut min_y, mut max_x, mut max_y) =
-        (std::f64::NAN, std::f64::NAN, std::f64::NAN, std::f64::NAN);
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (f64::NAN, f64::NAN, f64::NAN, f64::NAN);
     unsafe {
         assert_eq!(
             cavc_pline_eval_extents(pline, &mut min_x, &mut min_y, &mut max_x, &mut max_y),
@@ -410,9 +409,9 @@ fn pline_eval_parallel_offset() {
         let offset = -1.0;
         let mut options = cavc_pline_parallel_offset_o {
             aabb_index: std::ptr::null(),
-            pos_equal_eps: std::f64::NAN,
-            slice_join_eps: std::f64::NAN,
-            offset_dist_eps: std::f64::NAN,
+            pos_equal_eps: f64::NAN,
+            slice_join_eps: f64::NAN,
+            offset_dist_eps: f64::NAN,
             handle_self_intersects: 0,
         };
 
@@ -554,7 +553,7 @@ fn pline_eval_boolean() {
                 0
             );
 
-            let mut area = std::f64::NAN;
+            let mut area = f64::NAN;
             assert_eq!(cavc_pline_eval_area(output_pline, &mut area), 0);
             assert_fuzzy_eq!(area, 16.0);
 
@@ -637,7 +636,7 @@ fn pline_eval_boolean() {
 
         let mut options = cavc_pline_boolean_o {
             pline1_aabb_index: std::ptr::null(),
-            pos_equal_eps: std::f64::NAN,
+            pos_equal_eps: f64::NAN,
         };
 
         unsafe {
@@ -685,7 +684,7 @@ fn pline_eval_boolean() {
                 0
             );
 
-            let mut area = std::f64::NAN;
+            let mut area = f64::NAN;
             assert_eq!(cavc_pline_eval_area(output_pline, &mut area), 0);
             assert_fuzzy_eq!(area, 16.0);
 


### PR DESCRIPTION
Moves to Rust 1.85.0 and Rust 2024 edition.
Not much needed to change:
- rustfmt adjustments
- unsafe changes