### PR TITLE
Fix performance when zooming

### DIFF
--- a/cavalier_contours_ui/src/scenes/pline_offset_scene.rs
+++ b/cavalier_contours_ui/src/scenes/pline_offset_scene.rs
@@ -284,10 +284,6 @@ fn plot_area(
                     .vertex_color(Color32::LIGHT_GREEN),
             );
 
-            if *offset == 0.0 {
-                return;
-            }
-
             // TODO: color pickers
             match &scene_state {
                 SceneState::Offset { all_offset_plines } => {


### PR DESCRIPTION
- Add path culling based on visible area of plot (fixes major performance degradation when heavily zoomed - I think due to tessellation on for stroke paths with large numbers due to thresholding, maybe also can fix by adjusting thresholds)
- Culling should improve performance overall