### PR TITLE
Add minimum plot bounds check

### DIFF
--- a/cavalier_contours_ui/src/plotting/mod.rs
+++ b/cavalier_contours_ui/src/plotting/mod.rs
@@ -15,6 +15,13 @@ use lyon::{
 /// Plot vertex radius (in pixels) for drawing vertices.
 pub const PLOT_VERTEX_RADIUS: f32 = 4.0;
 
+/// Minimum plot width/height for drawing. This avoids degenerate behavior when super zoomed in.
+const MIN_PLOT_SIZE: f64 = 1e-5;
+
+fn plot_bounds_valid(bounds: &egui_plot::PlotBounds) -> bool {
+    bounds.width() >= MIN_PLOT_SIZE && bounds.height() >= MIN_PLOT_SIZE
+}
+
 /// Convert cavalier contours Vector2 to lyon Point adjusted for plot using plo transform.
 fn lyon_point(v: Vector2, transform: &PlotTransform) -> lyon::math::Point {
     lyon::math::point(

--- a/cavalier_contours_ui/src/plotting/plines.rs
+++ b/cavalier_contours_ui/src/plotting/plines.rs
@@ -20,6 +20,7 @@ use crate::plotting::plotbounds_to_aabb;
 
 use super::{
     PLOT_VERTEX_RADIUS, VertexConstructor, aabb_to_plotbounds, cull_path, empty_aabb, lyon_point,
+    plot_bounds_valid,
 };
 
 /// Core trait for plotting polylines data, supports plotting multiple polylines.
@@ -165,6 +166,9 @@ where
     T: PlinesPlotData,
 {
     fn shapes(&self, _ui: &egui::Ui, transform: &PlotTransform, shapes: &mut Vec<egui::Shape>) {
+        if !plot_bounds_valid(transform.bounds()) {
+            return;
+        }
         let plot_bounds = plotbounds_to_aabb(transform.bounds());
         if !plot_bounds.overlaps_aabb(&self.data.bounds()) {
             return;

--- a/cavalier_contours_ui/src/plotting/raw_pline_offset_segs.rs
+++ b/cavalier_contours_ui/src/plotting/raw_pline_offset_segs.rs
@@ -13,7 +13,7 @@ use lyon::{
     tessellation::{BuffersBuilder, StrokeOptions, StrokeTessellator, VertexBuffers},
 };
 
-use super::{VertexConstructor, aabb_to_plotbounds, cull_path, lyon_point};
+use super::{VertexConstructor, aabb_to_plotbounds, cull_path, lyon_point, plot_bounds_valid};
 
 pub struct RawPlineOffsetSegsPlotItem<'a> {
     pub segs: &'a [RawPlineOffsetSeg<f64>],
@@ -55,6 +55,10 @@ impl PlotItem for RawPlineOffsetSegsPlotItem<'_> {
         transform: &egui_plot::PlotTransform,
         shapes: &mut Vec<egui::Shape>,
     ) {
+        if !plot_bounds_valid(transform.bounds()) {
+            return;
+        }
+
         if self.segs.is_empty() {
             return;
         }


### PR DESCRIPTION
Culling path helped reduce weird performance degradation when super zoomed but didn't fix it entirely. Added minimum bounds check to avoid rendering plot items entirely if plot bounds is tiny.