### PR TITLE
Fix arc arc seg touch intersect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the cavalier_contours crate will be documented in this file.
 
+## Unreleased
+
+### Added ⭐
+
+- ⚠️ BREAKING: Added collapsed area parameter to pline boolean options to allow for pruning
+  collapsed polylines from results. This is only breaking due to struct initialization, if you use
+  default initialization this defaults to no change in behavior ([#71](https://github.com/jbuckmccready/cavalier_contours/pull/71)).
+
+### Fixed 🐛
+
+- Fixed bug in pline segment intersection when two arcs only touch at endpoints at one point, have
+  the same arc radius and center, and are in opposite directions. This also fixes some cases for
+  algorithms that depend on finding interescts (boolean, offset, etc.) ([#71](https://github.com/jbuckmccready/cavalier_contours/pull/71)).
+
 ## 0.6.0 2025-07-08
 
 ### Added ⭐

--- a/cavalier_contours/src/polyline/internal/pline_boolean.rs
+++ b/cavalier_contours/src/polyline/internal/pline_boolean.rs
@@ -676,6 +676,7 @@ pub fn stitch_slices_into_closed_polylines<P, R, T, S, O>(
     source_pline2: &R,
     stitch_selector: &S,
     pos_equal_eps: T,
+    collapsed_area_eps: Option<T>,
 ) -> Vec<BooleanResultPline<O>>
 where
     P: PlineSource<Num = T> + ?Sized,
@@ -722,6 +723,12 @@ where
         }
         pline.remove_last();
         pline.set_is_closed(true);
+        if let Some(collapsed_area) = collapsed_area_eps
+            && pline.area().abs() < collapsed_area
+        {
+            // skip slice with area less than collapsed_area_eps
+            return;
+        }
         result.push(BooleanResultPline::new(pline, subslices));
     };
 
@@ -867,6 +874,7 @@ where
     let is_pline2_in_pline1 = || pline1.winding_number(pline2.at(0).pos()) != 0;
 
     let pos_equal_eps = options.pos_equal_eps;
+    let collapsed_area_eps = options.collapsed_area_eps;
 
     match operation {
         BooleanOp::Or => {
@@ -913,6 +921,7 @@ where
                     pline2,
                     &stitch_selector,
                     pos_equal_eps,
+                    collapsed_area_eps,
                 );
 
                 let mut pos_plines = Vec::new();
@@ -972,6 +981,7 @@ where
                     pline2,
                     &stitch_selector,
                     pos_equal_eps,
+                    collapsed_area_eps,
                 );
 
                 BooleanResult::new(pos_plines, Vec::new(), BooleanResultInfo::Intersected)
@@ -1014,6 +1024,7 @@ where
                     pline2,
                     &stitch_selector,
                     pos_equal_eps,
+                    collapsed_area_eps,
                 );
 
                 BooleanResult::new(pos_plines, Vec::new(), BooleanResultInfo::Intersected)
@@ -1055,6 +1066,7 @@ where
                     pline2,
                     &stitch_selector1,
                     pos_equal_eps,
+                    collapsed_area_eps,
                 );
 
                 // collect pline2 NOT pline1 results
@@ -1074,6 +1086,7 @@ where
                     pline2,
                     &stitch_selector2,
                     pos_equal_eps,
+                    collapsed_area_eps,
                 );
 
                 remaining1.extend(remaining2);

--- a/cavalier_contours/src/polyline/pline_seg_intersect.rs
+++ b/cavalier_contours/src/polyline/pline_seg_intersect.rs
@@ -465,7 +465,14 @@ where
                 }
                 (false, true) => {
                     // only touch at start of arc2
-                    OneIntersect { point: u1.pos() }
+                    // NOTE: have to check and adjust for the direction flip done above to have
+                    // matching direction
+                    let point = if same_direction_arcs {
+                        u1.pos()
+                    } else {
+                        u2.pos()
+                    };
+                    OneIntersect { point }
                 }
                 (false, false) => {
                     // not just the end points touch, determine how the arcs overlap

--- a/cavalier_contours/src/polyline/pline_types.rs
+++ b/cavalier_contours/src/polyline/pline_types.rs
@@ -271,6 +271,11 @@ where
     pub pline1_aabb_index: Option<&'a StaticAABB2DIndex<T>>,
     /// Fuzzy comparison epsilon used for determining if two positions are equal.
     pub pos_equal_eps: T,
+    /// If Some then this epsilon value is used to determine if a result polyline is collapsed, that
+    /// is has no area according to abs(area) < eps. Polylines that are collapsed will not be
+    /// included in the result. This is useful to avoid inconsistent results due to floating point
+    /// thresholding, or if you just don't want ever want collapsed polylines in the result.
+    pub collapsed_area_eps: Option<T>,
 }
 
 impl<T> PlineBooleanOptions<'_, T>
@@ -282,6 +287,7 @@ where
         Self {
             pline1_aabb_index: None,
             pos_equal_eps: T::from(1e-5).unwrap(),
+            collapsed_area_eps: None,
         }
     }
 }

--- a/cavalier_contours_ffi/src/lib.rs
+++ b/cavalier_contours_ffi/src/lib.rs
@@ -189,6 +189,8 @@ pub unsafe extern "C" fn cavc_pline_parallel_offset_o_init(
 pub struct cavc_pline_boolean_o {
     pub pline1_aabb_index: *const cavc_aabbindex,
     pub pos_equal_eps: f64,
+    /// NOTE: optional parameter, set to NaN for None.
+    pub collapsed_area_eps: f64,
 }
 
 impl cavc_pline_boolean_o {
@@ -202,6 +204,11 @@ impl cavc_pline_boolean_o {
         PlineBooleanOptions {
             pline1_aabb_index,
             pos_equal_eps: self.pos_equal_eps,
+            collapsed_area_eps: if self.collapsed_area_eps.is_nan() {
+                None
+            } else {
+                Some(self.collapsed_area_eps)
+            },
         }
     }
 }
@@ -212,6 +219,7 @@ impl Default for cavc_pline_boolean_o {
         Self {
             pline1_aabb_index: std::ptr::null(),
             pos_equal_eps: d.pos_equal_eps,
+            collapsed_area_eps: f64::NAN,
         }
     }
 }

--- a/cavalier_contours_ffi/tests/test_pline.rs
+++ b/cavalier_contours_ffi/tests/test_pline.rs
@@ -647,6 +647,7 @@ fn pline_eval_boolean() {
         let mut options = cavc_pline_boolean_o {
             pline1_aabb_index: std::ptr::null(),
             pos_equal_eps: f64::NAN,
+            collapsed_area_eps: f64::NAN,
         };
 
         unsafe {


### PR DESCRIPTION
Fixed bug in pline segment intersection when two arcs only touch at endpoints at one point, have the same arc radius and center, and are in opposite directions. This also fixes some cases for algorithms that depend on finding interescts (boolean, offset, etc.).

This fixes https://github.com/jbuckmccready/cavalier_contours/issues/42
