### PR TITLE
fix(offset): sanitize repeat-position input and guard degenerate normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the cavalier_contours crate will be documented in this fi
 
 ## Unreleased
 
+### Fixed 🐛
+
+- Improved `parallel_offset` robustness for repeat-position/degenerate input by sanitizing repeat
+  vertices in release builds and guarding offset vector normalization against near-zero vectors.
+
 ## 0.7.0 - 2026-01-02
 
 ### Added ⭐


### PR DESCRIPTION
## Summary
- sanitize repeat-position vertices in parallel_offset runtime path (not debug-only)
- avoid reusing user-provided abb_index after sanitization; rebuild index for cleaned source
- guard near-zero vector normalization/perp computation in raw offset segment generation
- preserve userdata on output polylines after the sanitized flow
- add regression tests for repeat-position input (with and without external abb_index)
- update CHANGELOG.md under Unreleased

## Testing
- cargo test --test test_pline_parallel_offset repeat_position_input -- --nocapture
- cargo test -p cavalier_contours
