### PR TITLE
Fix debug panic for collapsed near-vertex polyline offset slices

### DIFF
--- a/cavalier_contours/src/polyline/pline_view.rs
+++ b/cavalier_contours/src/polyline/pline_view.rs
@@ -586,6 +586,11 @@ where
                 end_point,
                 pos_equal_eps,
             )
+        } else if traverse_count == 1
+            && end_point.fuzzy_eq_eps(source.at(end_index).pos(), pos_equal_eps)
+            && updated_start.pos().fuzzy_eq_eps(end_point, pos_equal_eps)
+        {
+            None
         } else {
             Some(Self::create(
                 source,

--- a/cavalier_contours/tests/test_pline_view.rs
+++ b/cavalier_contours/tests/test_pline_view.rs
@@ -191,6 +191,26 @@ fn from_slice_points_single_seg() {
 }
 
 #[test]
+fn from_slice_points_collapsed_across_near_vertex() {
+    let pline = pline_open![
+        (0.0, 0.0, 0.0),
+        (0.0, POS_EQ_EPS * 1.1, 0.0),
+        (0.0, -1.0, 0.0)
+    ];
+
+    let slice = PlineViewData::from_slice_points(
+        &pline,
+        Vector2::new(0.0, 0.0),
+        0,
+        Vector2::new(0.0, POS_EQ_EPS * 0.55),
+        1,
+        POS_EQ_EPS,
+    );
+
+    assert!(slice.is_none());
+}
+
+#[test]
 fn from_slice_points_multi_seg() {
     let pline = pline_closed![(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)];
     // complete polyline


### PR DESCRIPTION
A fix for a (debug-only) panic in `parallel_offset` caused by a degenerate `PlineViewData` slice during offset slice construction, see https://github.com/jbuckmccready/cavalier_contours/issues/79

The cause was when a slice crossed a raw offset seg but its start and end points were within eps. The problem is that `from_slice_points` still forwards it to `create`, which normalizes the point, which the debug validator then rejects. 

This is valid collapsed geometry and should be discarded, matching the existing behavior for collapsed slices on a single segment.

The fix is to detect collapsed one-segment-across-a-vertex slices in `PlineViewData::from_slice_points` and return `None`.

I also added a small focused regression test covering the near-vertex collapsed slice case: `from_slice_points_collapsed_across_near_vertex`.